### PR TITLE
WIP: Disable add button for legacy Capability; Add filtering for test Capability

### DIFF
--- a/fake_dependencies/capability-service/capability-data.json
+++ b/fake_dependencies/capability-service/capability-data.json
@@ -9,7 +9,8 @@
           }
         ],
         "contexts": [],
-        "Topics": []
+        "Topics": [],
+        "RootId": "foo-5234"
     },
     {
       "id": "2",

--- a/fake_dependencies/capability-service/capability-data.json
+++ b/fake_dependencies/capability-service/capability-data.json
@@ -10,7 +10,7 @@
         ],
         "contexts": [],
         "Topics": [],
-        "RootId": "foo-5234"
+        "RootId": "foo-1"
     },
     {
       "id": "2",
@@ -35,7 +35,8 @@
         "email": "highlander@me.com"
       }
     ],
-    "contexts": []
+    "contexts": [],
+    "RootId": null
   },
   {
     "id": "4",
@@ -47,7 +48,7 @@
       }
     ],
     "contexts": [],
-    "RootId": "testtitle-98237"
+    "RootId": "testtitle-4"
   },
   {
     "id": "5",
@@ -62,6 +63,21 @@
       }
     ],
     "contexts": [],
-    "RootId": "hellopelle-98237"
+    "RootId": "hellopelle-5"
+  },
+  {
+    "id": "6",
+    "name": "DockingEnvi",
+    "description": "dockingenviDescription",
+    "members": [
+      {
+        "email": "highlander@me.com"
+      },
+      {
+        "email": "jdog@me.com"
+      }
+    ],
+    "contexts": [],
+    "RootId": ""
   }
 ] 

--- a/fake_dependencies/capability-service/capability-data.json
+++ b/fake_dependencies/capability-service/capability-data.json
@@ -36,5 +36,32 @@
       }
     ],
     "contexts": []
+  },
+  {
+    "id": "4",
+    "name": "TestTitle",
+    "description": "testtitleDescription",
+    "members": [
+      {
+        "email": "highlander@me.com"
+      }
+    ],
+    "contexts": [],
+    "RootId": "testtitle-98237"
+  },
+  {
+    "id": "5",
+    "name": "HelloPelle",
+    "description": "hellopelleDescription",
+    "members": [
+      {
+        "email": "highlander@me.com"
+      },
+      {
+        "email": "jdog@me.com"
+      }
+    ],
+    "contexts": [],
+    "RootId": "hellopelle-98237"
   }
 ] 

--- a/src/Blaster.WebApi/Features/Capabilities/Models/Capability.cs
+++ b/src/Blaster.WebApi/Features/Capabilities/Models/Capability.cs
@@ -5,6 +5,7 @@
         public string Id { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public string RootId { get; set; }
         public Member[] Members { get; set; }
         public Context[] Contexts { get; set; }
         public Topic[] Topics {get;set;}

--- a/src/Blaster.WebApi/Features/Capabilities/main.js
+++ b/src/Blaster.WebApi/Features/Capabilities/main.js
@@ -4,6 +4,7 @@ import AlertDialog from "./alert-dialog";
 import ModelEditor from "modeleditor";
 import jq from "jquery";
 import { currentUser } from "userservice";
+import TestCapabilitiesFiltered from './test-filter';
 
 const capabilityService = new CapabilityService();
 
@@ -95,9 +96,33 @@ const app = new Vue({
         }
     },
     mounted: function () {
+        var featureflag_testFilter = new URLSearchParams(window.location.search).get('ff_testfilter');
+        if (featureflag_testFilter == null) {
+            featureflag_testFilter = 0;
+        } else {
+            featureflag_testFilter = 1;
+        }
+
         jq.ready
             .then(() => capabilityService.getAll())
             .then(capabilities => capabilities.forEach(capability => this.items.push(capability)))
+            .then(() => {
+                if (featureflag_testFilter === 1) {
+                    var capabilitiesToFilter = TestCapabilitiesFiltered;
+                    var filteredItems = [];
+
+                    for (var i = 0; i < this.items.length; i++) {
+                        var item = this.items[i];
+                        
+                        var filteredItem = capabilitiesToFilter[item.id];
+                        if (filteredItem != "") {
+                            filteredItems.push(item);
+                        }
+                    }
+
+                    this.items = filteredItems;
+                }
+            })
             .catch(info => {
                 if (info.status != 200) {
                     AlertDialog.open({

--- a/src/Blaster.WebApi/Features/Capabilities/main.js
+++ b/src/Blaster.WebApi/Features/Capabilities/main.js
@@ -96,8 +96,9 @@ const app = new Vue({
         }
     },
     mounted: function () {
-        var featureflag_testFilter = new URLSearchParams(window.location.search).get('ff_testfilter');
-        if (featureflag_testFilter === null) {
+        const featureflag_testFilter_queryParam = new URLSearchParams(window.location.search).get('ff_testfilter');
+        var featureflag_testFilter = false;
+        if (featureflag_testFilter_queryParam === null) {
             featureflag_testFilter = false;
         } else {
             featureflag_testFilter = true;
@@ -108,17 +109,7 @@ const app = new Vue({
             .then(capabilities => capabilities.forEach(capability => this.items.push(capability)))
             .then(() => {
                 if (!featureflag_testFilter) {
-                    var capabilitiesToFilter = TestCapabilitiesFiltered;
-                    var filteredItems = [];
-    
-                    for (var i = 0; i < this.items.length; i++) {
-                        var item = this.items[i];
-                        if (!capabilitiesToFilter.has(item.id)) {
-                            filteredItems.push(item);
-                        }
-                    }
-    
-                    this.items = filteredItems;
+                    this.items = this.items.filter(item => !TestCapabilitiesFiltered.has(item.id));
                 }
             })
             .catch(info => {

--- a/src/Blaster.WebApi/Features/Capabilities/main.js
+++ b/src/Blaster.WebApi/Features/Capabilities/main.js
@@ -97,29 +97,27 @@ const app = new Vue({
     },
     mounted: function () {
         var featureflag_testFilter = new URLSearchParams(window.location.search).get('ff_testfilter');
-        if (featureflag_testFilter == null) {
-            featureflag_testFilter = 0;
+        if (featureflag_testFilter === null) {
+            featureflag_testFilter = false;
         } else {
-            featureflag_testFilter = 1;
+            featureflag_testFilter = true;
         }
 
         jq.ready
             .then(() => capabilityService.getAll())
             .then(capabilities => capabilities.forEach(capability => this.items.push(capability)))
             .then(() => {
-                if (featureflag_testFilter === 1) {
+                if (!featureflag_testFilter) {
                     var capabilitiesToFilter = TestCapabilitiesFiltered;
                     var filteredItems = [];
-
+    
                     for (var i = 0; i < this.items.length; i++) {
                         var item = this.items[i];
-                        
-                        var filteredItem = capabilitiesToFilter[item.id];
-                        if (filteredItem != "") {
+                        if (!capabilitiesToFilter.has(item.id)) {
                             filteredItems.push(item);
                         }
                     }
-
+    
                     this.items = filteredItems;
                 }
             })

--- a/src/Blaster.WebApi/Features/Capabilities/main.js
+++ b/src/Blaster.WebApi/Features/Capabilities/main.js
@@ -97,12 +97,7 @@ const app = new Vue({
     },
     mounted: function () {
         const featureflag_testFilter_queryParam = new URLSearchParams(window.location.search).get('ff_testfilter');
-        var featureflag_testFilter = false;
-        if (featureflag_testFilter_queryParam === null) {
-            featureflag_testFilter = false;
-        } else {
-            featureflag_testFilter = true;
-        }
+        const featureflag_testFilter = featureflag_testFilter_queryParam !== null;
 
         jq.ready
             .then(() => capabilityService.getAll())

--- a/src/Blaster.WebApi/Features/Capabilities/test-filter.js
+++ b/src/Blaster.WebApi/Features/Capabilities/test-filter.js
@@ -1,6 +1,6 @@
-const FilteredCapabilities = {};
-FilteredCapabilities["4"] = ""
-FilteredCapabilities["5"] = ""
+const FilteredCapabilities = new Set(["926458e2-4468-4bca-97b0-520584ccc0f4", "4e01a646-9a0f-4c33-905e-2abef8d96730", "78c4e6e2-127c-4cbd-b0e2-0dd8dfcf5fbc", "5cb28c0e-87a2-43ed-a3b2-bedbb02d5757",
+                                        "c3b3f403-d259-42de-83b0-604874808d0e", "1ca9fd66-aa1b-46f9-9657-68f26657478c", "a1fc255f-cfc4-46b4-9831-82a239e088bb", "c56a4853-ec73-48ee-8ab4-64ffc56d5586", 
+                                        "c73e9e9e-a9ac-430e-baee-b08b97c6a58b", "4ed8f786-c700-4562-80a8-27e444215853", "bcf07274-2ac1-44e7-aeb9-fadba80c97db", "826a0440-af08-4721-8c14-2db8a3f127d0"]);
 
 export {FilteredCapabilities};
 export default FilteredCapabilities;

--- a/src/Blaster.WebApi/Features/Capabilities/test-filter.js
+++ b/src/Blaster.WebApi/Features/Capabilities/test-filter.js
@@ -1,0 +1,6 @@
+const FilteredCapabilities = {};
+FilteredCapabilities["4"] = ""
+FilteredCapabilities["5"] = ""
+
+export {FilteredCapabilities};
+export default FilteredCapabilities;

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
@@ -30,6 +30,7 @@
                         <button
                             type="button"
                             class="button is-small is-primary"
+                            :disabled='isLegacyComputed'
                             v-on:click="addContext()"
                             v-if="getContextStatusFor() == 'notadded'">
                             Add AWS account and K8s namespace

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
@@ -30,7 +30,9 @@
                         <button
                             type="button"
                             class="button is-small is-primary"
+                            v-bind:class="{tooltip: isAddContextDisallowedComputed, 'is-tooltip-bottom': isAddContextDisallowedComputed, 'is-tooltip-multiline': isAddContextDisallowedComputed }"
                             :disabled='isAddContextDisallowedComputed'
+                            :data-tooltip="disabledContextButtonReasonComputed"
                             v-on:click="addContext()"
                             v-if="getContextStatusFor() == 'notadded'">
                             Add AWS account and K8s namespace

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/Index.cshtml
@@ -30,7 +30,7 @@
                         <button
                             type="button"
                             class="button is-small is-primary"
-                            :disabled='isLegacyComputed'
+                            :disabled='isAddContextDisallowedComputed'
                             v-on:click="addContext()"
                             v-if="getContextStatusFor() == 'notadded'">
                             Add AWS account and K8s namespace

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -25,7 +25,10 @@ const app = new Vue({
         isLegacyComputed: function () { // Determine if Capability is v1 or v2
             if (this.capability) // Ensure capability object exists
             {
-                if (this.capability.rootId) {
+                if (this.capability.rootId) { // Check if rootId is null
+                    if (this.capability.rootId === "") {
+                        return true;
+                    }
                     return false;
                 } else {
                     return true;

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -20,7 +20,17 @@ const app = new Vue({
     },
     computed: {
         capabilityFound: function() {
-            return this.capability != null && this.capability.id != null 
+            return this.capability != null && this.capability.id != null
+        },
+        isLegacyComputed: function () { // Determine if Capability is v1 or v2
+            if (this.capability) // Ensure capability object exists
+            {
+                if (this.capability.rootId) {
+                    return false;
+                } else {
+                    return true;
+                }
+            }
         }
     },
     filters: {

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -28,11 +28,11 @@ const app = new Vue({
                 if (this.capability.rootId) { // Check if rootId is null
                     if (this.capability.rootId === "") {
                         return true;
+                    } else {
+                        return false;
                     }
-                    return false;
-                } else {
-                    return true;
                 }
+                return true;
             }
         },
         isJoinedComputed: function () {
@@ -55,18 +55,13 @@ const app = new Vue({
         },
         disabledContextButtonReasonComputed: function() {
             if (this.isAddContextDisallowedComputed) {
-                console.log("Context button will be disabled, writing error tooltip.");
-
                 var msg = "Reason(s) why this button is disabled:" + "\n";
-
                 if (!this.isJoinedComputed) {
                     msg = msg + "You haven't joined this Capability." + "\n";
                 }
-
                 if (this.isLegacyComputed) {
                     msg = msg + "This Capability is discontinued. Consider creating a new Capability." + "\n";
                 }
-
                 return msg;
             } else {
                 return "";

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -52,6 +52,25 @@ const app = new Vue({
             } else {
                 return true;
             }
+        },
+        disabledContextButtonReasonComputed: function() {
+            if (this.isAddContextDisallowedComputed) {
+                console.log("Context button will be disabled, writing error tooltip.");
+
+                var msg = "Reason(s) why this button is disabled:" + "\n";
+
+                if (!this.isJoinedComputed) {
+                    msg = msg + "You haven't joined this Capability." + "\n";
+                }
+
+                if (this.isLegacyComputed) {
+                    msg = msg + "This Capability is discontinued. Consider creating a new Capability." + "\n";
+                }
+
+                return msg;
+            } else {
+                return "";
+            }
         }
     },
     filters: {

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -37,11 +37,7 @@ const app = new Vue({
         },
         isJoinedComputed: function () {
             var isMemberRawText = this.getMembershipStatusFor();
-            if (isMemberRawText === "member") {
-                return true;
-            } else {
-                return false;
-            }
+            return isMemberRawText === "member";
         },
         isAddContextDisallowedComputed: function() {
             var isLegacy = this.isLegacyComputed;

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -34,6 +34,24 @@ const app = new Vue({
                     return true;
                 }
             }
+        },
+        isJoinedComputed: function () {
+            var isMemberRawText = this.getMembershipStatusFor();
+            if (isMemberRawText === "member") {
+                return true;
+            } else {
+                return false;
+            }
+        },
+        isAddContextDisallowedComputed: function() {
+            var isLegacy = this.isLegacyComputed;
+            var isJoined = this.isJoinedComputed;
+
+            if (isLegacy == false && isJoined == true) {
+                return false;
+            } else {
+                return true;
+            }
         }
     },
     filters: {

--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -25,14 +25,7 @@ const app = new Vue({
         isLegacyComputed: function () { // Determine if Capability is v1 or v2
             if (this.capability) // Ensure capability object exists
             {
-                if (this.capability.rootId) { // Check if rootId is null
-                    if (this.capability.rootId === "") {
-                        return true;
-                    } else {
-                        return false;
-                    }
-                }
-                return true;
+                return (this.capability.rootId) ? (this.capability.rootId === "") : true;
             }
         },
         isJoinedComputed: function () {
@@ -42,26 +35,20 @@ const app = new Vue({
         isAddContextDisallowedComputed: function() {
             var isLegacy = this.isLegacyComputed;
             var isJoined = this.isJoinedComputed;
-
-            if (isLegacy == false && isJoined == true) {
-                return false;
-            } else {
-                return true;
-            }
+            return !(isLegacy == false && isJoined == true);
         },
         disabledContextButtonReasonComputed: function() {
+            var msg = "";
             if (this.isAddContextDisallowedComputed) {
-                var msg = "Reason(s) why this button is disabled:" + "\n";
+                msg = "Reason(s) why this button is disabled:" + "\n";
                 if (!this.isJoinedComputed) {
                     msg = msg + "You haven't joined this Capability." + "\n";
                 }
                 if (this.isLegacyComputed) {
                     msg = msg + "This Capability is discontinued. Consider creating a new Capability." + "\n";
                 }
-                return msg;
-            } else {
-                return "";
-            }
+            } 
+            return msg;
         }
     },
     filters: {

--- a/src/Blaster.WebApi/Features/Shared/styles.scss
+++ b/src/Blaster.WebApi/Features/Shared/styles.scss
@@ -46,6 +46,7 @@ $navbar-item-hover-background-color: $group-blue;
 $navbar-padding-horizontal: 10em;
 
 @import "~bulma/bulma";
+@import "~bulma-extensions/bulma-tooltip/src/sass/index";
 
 [v-cloak] {
     display: none;

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
     "babel-loader": "^7.1.5",
     "babel-preset-env": "^1.7.0",
     "bulma": "^0.7.4",
+    "bulma-extensions": "^6.2.7",
     "css-loader": "^2.1.1",
     "file-loader": "^3.0.1",
     "jquery": "^3.4.0",


### PR DESCRIPTION
- [x] Disable "Add AWS account and K8s namespace" button for legacy Capability
- [x] Add ability to filter "test" Capability, as well as functionality to toggle this with a query parameter/string

  This is being toggled by appending "ff_testfilter" to your query parameters, e.g. ```localhost:8080/capabilities?ff_testfilter``` Filter is enabled
```localhost:8080/capabilities?``` Filter is disabled


Added 26.06.2019:
- [x] If user hasn't joined Capability, make sure they can't add a Context.
- [x] Add tooltip for disabled "Add AWS account and K8s namespace" button