### PR TITLE
Local dev replica of CapabilityService now serves a RootId

### DIFF
--- a/fake_dependencies/capability-service/package.json
+++ b/fake_dependencies/capability-service/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+    "uuid": "^3.3.2"
   }
 }

--- a/fake_dependencies/capability-service/server.js
+++ b/fake_dependencies/capability-service/server.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const fs = require("fs");
 const util = require("util");
+const uuidv1 = require('uuid/v1');
 
 const port = process.env.port || 3000;
 
@@ -41,6 +42,9 @@ app.post("/api/v1/capabilities", (req, res) => {
         // Null or undefined
         newTeam.description = "generic description"
     }
+
+    // RootId generation
+    newTeam.RootId = (newTeam.name.substring(0, 20) + "-" + uuidv1().substring(0, 8)).toLocaleLowerCase();
 
     readFile("./capability-data.json")
         .then(data => JSON.parse(data))


### PR DESCRIPTION
The issue at hand is that the frontend in Blaster assumes if no RootId is given, that said Capability is "discontinued" or v1. Since the local replica of CapabilityService doesn't give new a new Capability a RootId, this disables the "Add AWS account and K8s namespace" button in the "capabilitydashboard" view.