### PR TITLE
No more undefined returns in isLegacyComputed

### DIFF
--- a/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
+++ b/src/Blaster.WebApi/Features/CapabilityDashboard/main.js
@@ -23,10 +23,8 @@ const app = new Vue({
             return this.capability != null && this.capability.id != null
         },
         isLegacyComputed: function () { // Determine if Capability is v1 or v2
-            if (this.capability) // Ensure capability object exists
-            {
-                return (this.capability.rootId) ? (this.capability.rootId === "") : true;
-            }
+            const isRootIdEmpty = (this.capability.rootId) ? (this.capability.rootId === "") : true;
+            return (this.capability) ? isRootIdEmpty : false; // Ensure capability object exists
         },
         isJoinedComputed: function () {
             var isMemberRawText = this.getMembershipStatusFor();


### PR DESCRIPTION
Currently(latest commit in Master: d20364abdba58543ec06a9a6b85b09a2d887c270) the function called isLegacyComputed found in the path ```src/Blaster.WebApi/Features/CapabilityDashboard/main.js``` looks like this:

```
isLegacyComputed: function () { // Determine if Capability is v1 or v2
    if (this.capability) // Ensure capability object exists
    {
        return (this.capability.rootId) ? (this.capability.rootId === "") : true;
    }
}
```

As one might quickly notice, there is a path in that code where nothing gets returned. While this is perfectly valid Javascript, it would be nice to be able to expect a consistent type when one calls this function. With the current usage of this function throughout the codebase, this isn't an issue, since all calls to it is originating from an Vue component, that simply doesn't get loaded if _capabilityFound_ doesn't return true. 

Since this may not always been the case going forward, _isLegacyComputed_ will always been returning a boolean, instead of sometimes returning a boolean or undefined.