### PR TITLE
Bump set-value from 2.0.0 to 2.0.1 in /src

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -5547,9 +5547,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",


### PR DESCRIPTION
GitHub alerted us about a vulnerable dependency. It usually creates a PR for us, but were unable to that in this particular instance.

CVE: https://nvd.nist.gov/vuln/detail/CVE-2019-10747