### PR TITLE
fix: Hamburger menu works again

### DIFF
--- a/src/Blaster.WebApi/Features/Shared/_Layout.cshtml
+++ b/src/Blaster.WebApi/Features/Shared/_Layout.cshtml
@@ -38,7 +38,7 @@
             </div>
 
             <div class="navbar-mobile">
-                <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="menu">
+                <a role="button" class="navbar-burger burger" v-bind:class="{'is-active': isActive}" v-on:click="toggleActive()" aria-label="menu" aria-expanded="false" data-target="menu">
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
                     <span aria-hidden="true"></span>
@@ -46,7 +46,7 @@
             </div>
         </div>
 
-        <div id="menu" class="navbar-menu">
+        <div id="menu" class="navbar-menu" v-bind:class="{'is-active': isActive}">
             <div class="navbar-start">
                 <a href="@Url.Action("Index", "Frontpage")" class="navbar-item">Home</a>
                 <a href="@Url.Action("Index", "Capability")" class="navbar-item">Capabilities</a>
@@ -75,17 +75,6 @@
 <script>
     window.basePath = "@Context.Request.PathBase";
     window.currentUserRazor = { email: "@UserHelper.CurrentUser.Email" };
-
-    (function() {
-        var burger = document.querySelector('.burger');
-        var menu = document.querySelector('#' + burger.dataset.target);
-        burger.addEventListener('click',
-            function () {
-                burger.classList.toggle('is-active');
-                menu.classList.toggle('is-active');
-            });
-    })();
-
 </script>
 
 <script src="~/main.bundle.js"></script>

--- a/src/Blaster.WebApi/Features/Shared/components/Shared.js
+++ b/src/Blaster.WebApi/Features/Shared/components/Shared.js
@@ -19,7 +19,7 @@ new Vue({
     },
     methods: {
         toggleActive: function () {
-            this.active = this.active ? false : true;
+            this.active = !this.active;
         }
     },
     computed: {

--- a/src/Blaster.WebApi/Features/Shared/components/Shared.js
+++ b/src/Blaster.WebApi/Features/Shared/components/Shared.js
@@ -16,8 +16,24 @@ new Vue({
         showIEBanner: function () {
             return isIE();
         }
+    },
+    methods: {
+        toggleActive: function () {
+            this.active = this.active ? false : true;
+        }
+    },
+    computed: {
+        isActive: function() {
+            return this.active;
+        }
+    },
+    data: {
+        active: false
     }
+    
 });
+
+
 
 function isIE()
 {


### PR DESCRIPTION
With the recent change of navbar being made it's own Vue instance instead of plain html/css/js, the previous 'magic' that made the hamburger navigation button work, stopped working. This PR is just a mere conversion of that functionality to something that works with the Vue virtual DOM.

**Broken**
![broken_nav](https://user-images.githubusercontent.com/1633308/69618151-b25f6d00-1039-11ea-9ccd-0ec0a94c09ab.gif)

**Fixed**
![working_nav](https://user-images.githubusercontent.com/1633308/69618175-bab7a800-1039-11ea-92d0-719a6939ef73.gif)
