### PR TITLE
Added status page to navbar with a link to dfdsit.statuspage.io

### DIFF
--- a/src/Blaster.WebApi/Features/Shared/_Layout.cshtml
+++ b/src/Blaster.WebApi/Features/Shared/_Layout.cshtml
@@ -53,6 +53,7 @@
                 <a href="https://playbooks.dfds.cloud" class="navbar-item">Playbooks</a>
                 <a href="https://github.com/dfds" class="navbar-item">GitHub (Code examples)</a>
                 <a href="@Url.Action("SharedComponents", "Frontpage")" class="navbar-item">UI</a>
+                <a href="https://dfdsit.statuspage.io" class="navbar-item">Status page</a>
             </div>
 
             <div class="navbar-end">


### PR DESCRIPTION
This might be filling up the navbar too much. But then we should do a "burger-menu" or something like that.

Closes #144 

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>