### PR TITLE
Fetch kubeconfig from public S3 bucket instead of aws-janitor

### DIFF
--- a/src/Blaster.WebApi/Features/Frontpage/FrontpageController.cs
+++ b/src/Blaster.WebApi/Features/Frontpage/FrontpageController.cs
@@ -27,9 +27,9 @@ namespace Blaster.WebApi.Features.Frontpage
         [HttpGet("/downloads/kubeconfig")]
         public async Task<IActionResult> DownloadKubeConfig()
         {
-            var defaultKubeConfig = await _client.GetDefaultKubeConfig();
+            var kubeConfigS3Url = "https://dfds-oxygen-k8s-public.s3-eu-west-1.amazonaws.com/kubeconfig/hellman-saml.config";
 
-            return File(defaultKubeConfig.Content, defaultKubeConfig.ContentType, defaultKubeConfig.FileName);
+            return Redirect(kubeConfigS3Url);
         }
     }
 }


### PR DESCRIPTION
It seems not ideal to have the kubeconfig propagate through all of our services, so let's fetch it from the source and reducing points of failure.